### PR TITLE
テイクアウトメニューの商品名のclass名を変更

### DIFF
--- a/menu.html
+++ b/menu.html
@@ -433,31 +433,31 @@
           <p class="takeout-category-concept">弁当や丼のテイクアウトで、家庭でも美味しい味を食べられるようになりました。特に<span class="impact">あんかけ丼はテイクアウト限定！</span>ぜひご賞味ください！</p>
         </div>
         <div class="takeout">
-          <p class="take-out-name">餃子弁当</p>
+          <p class="takeout-name">餃子弁当</p>
           <p class="price">&yen;650</p>
           <img src="img-menu/gyoza-box.jpg" alt="餃子弁当">
         </div>
 
         <div class="takeout">
-          <p class="take-out-name">野菜炒め弁当</p>
+          <p class="takeout-name">野菜炒め弁当</p>
           <p class="price">&yen;650</p>
           <img src="img-menu/vegetables-box.jpg" alt="野菜炒め弁当">
         </div>
 
         <div class="takeout">
-          <p class="take-out-name">スタミナ丼</p>
+          <p class="takeout-name">スタミナ丼</p>
           <p class="price">&yen;600</p>
           <img src="img-menu/sutamina.jpg" alt="スタミナ丼">
         </div>
 
         <div class="takeout">
-          <p class="take-out-name">チャーシュー丼</p>
+          <p class="takeout-name">チャーシュー丼</p>
           <p class="price">&yen;600</p>
           <img src="img-menu/take-char-siu.jpg" alt="チャーシュー丼">
         </div>
 
         <div class="takeout">
-          <p class="take-out-name">あんかけ丼</p>
+          <p class="takeout-name">あんかけ丼</p>
           <p class="price">&yen;600</p>
           <img src="img-menu/take-ankake.jpg" alt="あんかけ丼">
         </div>


### PR DESCRIPTION
## 作業内容
menu.htmlのテイクアウトメニュー欄において、商品名の p タグの class 名を変更した。

## 変更理由
商品名の文字が小さく、css のタグ名と html の p タグの名前が異なっていたため、統一して文字の大きさを大きくした。