### PR TITLE
アイコンがiphone と android にも表示されるように、html の headタグを修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,10 @@
   <meta name="description" content="うまい めんくい亭の公式サイトへようこそ！「美味しくて、また行きたい」そのような店であるように、日々精進してまいります！餃子・ラーメンへのこだわりから種類豊富なメニュー、店舗情報、求人情報がご覧いただけます。">
   <link rel = "stylesheet" href = "css/index.css">
   <link href="https://use.fontawesome.com/releases/v5.10.2/css/all.css" rel="stylesheet">
+  
   <link rel="shortcut icon" href="favicon.ico">
+  <link rel="apple-touch-icon" href="apple-touch-icon.png" sizes="180x180">
+  <link rel="icon" type="image/png" href="android-touch-icon.png" sizes="192x192">
 </head>
 <body>
   <div class="wrapper">

--- a/information.html
+++ b/information.html
@@ -14,7 +14,10 @@
   <meta name="description" content="茨城県日立市にあるラーメン店の老舗です。営業時間やお支払い方法などの店舗詳細の他、採用情報も掲載しております！">
   <link rel = "stylesheet" href = "css/information.css">
   <link href="https://use.fontawesome.com/releases/v5.10.2/css/all.css" rel="stylesheet">
+
   <link rel="shortcut icon" href="favicon.ico">
+  <link rel="apple-touch-icon" href="apple-touch-icon.png" sizes="180x180">
+  <link rel="icon" type="image/png" href="android-touch-icon.png" sizes="192x192">
 </head>
 <body>
   <header>

--- a/menu.html
+++ b/menu.html
@@ -14,7 +14,10 @@
   <meta name="description" content="多種多彩なメニューを取り揃えています。人気No.1 辛ネギ味噌ラーメン！店内手作り餃子！ぜひご賞味ください。">
   <link rel = "stylesheet" href = "css/menu.css">
   <link href="https://use.fontawesome.com/releases/v5.10.2/css/all.css" rel="stylesheet">
+
   <link rel="shortcut icon" href="favicon.ico">
+  <link rel="apple-touch-icon" href="apple-touch-icon.png" sizes="180x180">
+  <link rel="icon" type="image/png" href="android-touch-icon.png" sizes="192x192">
 </head>
 <body>
   <header>

--- a/quality.html
+++ b/quality.html
@@ -14,7 +14,10 @@
   <meta name="description" content="「こだわりの食料」「手作り」「感謝の心」この三つのこだわりで、お客様に美味しい料理を提供します。">
   <link rel = "stylesheet" href = "css/quality.css">
   <link href="https://use.fontawesome.com/releases/v5.10.2/css/all.css" rel="stylesheet">
+
   <link rel="shortcut icon" href="favicon.ico">
+  <link rel="apple-touch-icon" href="apple-touch-icon.png" sizes="180x180">
+  <link rel="icon" type="image/png" href="android-touch-icon.png" sizes="192x192">
 </head>
 <body>
   <header>


### PR DESCRIPTION
## 作業内容
html の head タグに、アイコンを表示させるための link タグを追加した。

## 変更理由
iPhone と Android 端末では、アイコンが正しく表示されていないことがわかったため、修正した。