### PR TITLE
メニューカテゴリーの文字の大きさを調整

### DIFF
--- a/css/menu.css
+++ b/css/menu.css
@@ -157,7 +157,7 @@ input[name="menu"] {
   font-size: 3rem;
 }
 .miso-category-concept, .ginger-sentence, .chuka-category-concept, .wantan-sentence, .syouyu-category-concept, .solt-category-concept {
-  font-size: 1.8rem;
+  font-size: 1.1rem;
   padding-left: 20px;
   text-align: justify;
   text-justify: auto;


### PR DESCRIPTION
## 変更概要
メニューのカテゴリーを説明する文章で、文字の大きさが大きいためにレイアウトが崩れてしまうことが確認された。そのため、font-sizeを 1.1rem に変更した。

## 対象のIssue
Closes #67 が対象のIssueである。