### PR TITLE
「当店のこだわり」ボタンの遷移先を修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
         <img class="concept-img" src="img/spicy.jpg" alt="辛ネギ味噌ラーメン">
         <div class="ramen-concept-title">
           <h2 class="ramen-concept-text">人気No.1<br>辛ネギ味噌ラーメン</h2>
-          <p><a class="menu-link-button" href="menu.html">> 当店のこだわり</a></p>
+          <p><a class="menu-link-button" href="quality.html">> 当店のこだわり</a></p>
         </div>
       </div>
 


### PR DESCRIPTION
## 概要
トップページの「当店のこだわり」ボタンからの遷移先がメニューになってしまっていた。
そのため、こだわりページに遷移するように修正をした。