### PR TITLE
メニューページの文字の大きさを修正

### DIFF
--- a/css/menu.css
+++ b/css/menu.css
@@ -144,15 +144,17 @@ input[name="menu"] {
   margin-bottom: 2%;
 }
 
+.price {
+  font-size: 1.5rem;
+}
+
+.miso-name, .category-miso, .miso-category-concept, .ginger-sentence {
+  color: #B22222;
+}
 .miso-name {
   font-size: 1.8rem;
-  color: #B22222;
-}
-.ginger-sentence {
-  color: #B22222;
 }
 .category-miso {
-  color: #B22222;
   font-size: 3rem;
 }
 .miso-category-concept, .ginger-sentence, .chuka-category-concept, .wantan-sentence, .syouyu-category-concept, .solt-category-concept {
@@ -161,32 +163,25 @@ input[name="menu"] {
   text-align: justify;
   text-justify: auto;
 }
-.miso-category-concept {
-  color: #B22222;
-}
 
+.chuka-name, .syouyu-name, .category-chuka, .category-syouyu, .chuka-category-concept, .syouyu-category-concept, .wantan-sentence {
+  color: red;
+}
 .chuka-name, .syouyu-name {
   font-size: 1.8rem;
-  color: red;
 }
 .category-chuka, .category-syouyu {
-  color: red;
   font-size: 3rem;
-}
-.chuka-category-concept, .wantan-sentence, .syouyu-category-concept{
-  color: red;
 }
 
+.solt-name, .category-solt, .solt-category-concept {
+  color: #007700;
+}
 .solt-name {
   font-size: 1.8rem;
-  color: #007700;
 }
 .category-solt {
-  color: #007700;
   font-size: 3rem;
-}
-.solt-category-concept {
-  color: #007700;
 }
 
 .other-name, .child-name, .rice-name, .side-name, .drink-name, .takeout-name {
@@ -196,12 +191,10 @@ input[name="menu"] {
   font-size: 3rem;
 }
 
-.category-alcohol, .category-takeout {
-  font-size: 2.6rem;
-}
-.category-drink {
+.category-alcohol, .category-drink, .category-takeout {
   font-size: 2.5rem;
 }
+
 .other-category-concept,.child-category-concept, .rice-category-concept, .drink-category-concept, .side-category-concept, .takeout-category-concept, .lunch-category-concept {
   color: #000;
   font: bold 1.1rem sans-serif;

--- a/menu.html
+++ b/menu.html
@@ -227,7 +227,7 @@
       <div id="menu">
         <div class="noodle other">
           <h2 class = "category-other">その他</h2>
-          <p class="other-category-concept">まぜ麺やつけ麺、坦々麺など人気商品もラインアップ!特にまぜ麺は、麺やタレを改良してのどごしやコクがアップしました!</p>
+          <p class="other-category-concept">まぜ麺やつけ麺、坦々麺など人気商品もラインアップ！特にまぜ麺は、麺やタレを改良して<span class="impact">のどごしとコクがアップ</span>しました！</p>
         </div>
         <div class="noodle other">
           <p class="other-name">まぜそば</p>
@@ -242,8 +242,10 @@
         </div>
 
         <div class="noodle other">
-          <p class="other-name">煮干しつけ麺<span class="space">&yen;850</span></p>
-          <p class="other-name">ピリ辛醤油つけ麺<span class="space">&yen;800</span></p>
+          <p class="other-name">煮干しつけ麺</p>
+          <p class="price">&yen;850</p>
+          <p class="other-name">ピリ辛醤油つけ麺</p>
+          <p class="price">&yen;800</p>
           <img src="img-menu/tukemen.jpg" alt="つけ麺 (煮干し or ピリ辛醤油)">
         </div>
       </div>
@@ -251,7 +253,7 @@
       <div id="menu">
         <div class="noodle child">
           <h2 class = "category-child">お子様</h2>
-          <p class="child-category-concept">子供には嬉しいお子様ラーメン!ジュースやおもちゃが無料でついてきます!醤油と味噌味からお選びいただけます!</p>
+          <p class="child-category-concept">子供には嬉しいお子様ラーメン!ジュースやおもちゃが無料でついてきます！醤油と味噌味からお選びいただけます!</p>
         </div>
         <div class="noodle child">
           <p class="child-name">お子様ラーメン<br>(醤油 or 味噌)</p>
@@ -263,7 +265,7 @@
       <div class="rice-menu" id="menu">
         <div class="rice">
           <h2 class = "category-rice">定食</h2>
-          <p class="rice-category-concept">スープや漬物、小鉢がついてお得!人気のサイドメニューを定食で食べることで、満足感UP!</p>
+          <p class="rice-category-concept">スープや漬物、小鉢がついてお得！人気のサイドメニューを定食で食べることで、満足感UP！</p>
         </div>
         <div class="rice">
           <p class="rice-name">餃子7個定食</p>


### PR DESCRIPTION
## 変更概要
以下の修正を行なった。
- メニューのカテゴリ名の大きさを調整した。（テイクアウトなどが一行で収まりきっていないので、収まるように修正)
- cssにおいて、共通箇所をまとめるリファクタリングを行う。

## 理想の状態
スマホで表示させた時も、カテゴリ名が改行されないように表示されていること。