### PR TITLE
見出しの下に赤線を追加

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -241,10 +241,12 @@ details summary {
   font: bold 1.4em sans-serif;
   padding: 0 30px;
 }
-.attempt-border {
-  border-bottom: 3px solid red;
-  color: red;
-  font-family: serif;
+.underline {
+  border-bottom: 10px solid red;
+}
+.attempt-underline {
+	color: red;
+	font-family: serif;
 }
 
 /* ポイントカード */

--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
       </div>
 
       <div class="news">
-        <h2 class = "news-title">お知らせ</h2>
+        <h2 class = "news-title"><span class="underline">お知らせ</h2></span>
         <div class="news-list">
           <ul>
             <li>
@@ -113,7 +113,7 @@
 
       <div class="takeout">
         <div class="takeout-text">
-          <h2 class="takeout-title">テイクアウト実施中！</h2>
+          <h2 class="takeout-title"><span class="underline">テイクアウト実施中！</span></h2>
           <p class="takeout-subtitle">サイドメニューのお持ち帰りに加えて、弁当と丼のテイクアウトも行っております！電話でも店舗でもご注文を受け付けております！ぜひご賞味ください！</p>
           <p><a class="menu-link-button" href="menu.html#take-out-menu">> メニューはこちら</a></p>
         </div>
@@ -124,7 +124,7 @@
       </div>
 
       <div class="attempt">
-        <h2 class="attempt-title"><span class="attempt-border">コロナ禍における取り組み</span></h2>
+        <h2 class="attempt-title"><span class="underline attempt-underline">コロナ禍における取り組み</span></h2>
         <p class="attempt-subtitle">お客様に安心してご来店いただけるよう、当店では以下のことを実施しております。</p>
         <div class="attempt-container">
           <div class="attempt-item">
@@ -151,7 +151,7 @@
 
       <div class="point">
         <div class="point-text">
-          <h2 class="point-title">ポイントカードで餃子をお得に！</h2>
+          <h2 class="point-title"><span class="underline">ポイントカードで餃子をお得に！</span></h2>
           <p class="point-subtitle">
             とってもお得なめんくい亭のポイントカードをご存知ですか？
             当店のポイントカードは5回のご来店で<span class="impact">餃子が一枚無料！</span>期限はないので、いつでもご利用いただけます！


### PR DESCRIPTION
## 変更内容
Issues の Closes #91 の内容を修正した。
具体的には、トップページの見出しの下に、赤線を追加した。

## 変更理由
見出しの文字が、あまり強調されてないため。
下線をつけることで、見出しの文字が強調されるため、変更した。

## 変更箇所
各見出しのタイトルの前に、<span class="underline"> を追加した。