### PR TITLE
冷やし中華のお知らせ追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,6 +55,22 @@
           <ul>
             <li>
               <div class="news-list-head">
+                <span class="news-update-date">2022.6.24</span>
+                <span class="news-tag notice">お知らせ</span>
+                <h3 class="news-topic">夏の定番！ 冷やし中華始めました！</h3>
+              </div>
+              <details>
+                <summary>詳細はこちら</summary>
+                <p class="news-text">
+                  日頃より「うまいめんくい亭」をご利用いただき誠にありがとうございます。<br>
+                  言わずと知れた夏の定番！<span class="impact news-impact">冷やし中華が今年も始まりました！！</span><br>
+                  つるっとした喉越し。具沢山で栄養満点。さっぱり醤油だれと、まろやか胡麻だれ。<br>
+                  夏だけの期間限定！是非ご賞味ください！
+                </p>
+              </details>
+            </li>
+            <li>
+              <div class="news-list-head">
                 <span class="news-update-date">2022.3.20</span>
                 <span class="news-tag notice">お知らせ</span>
                 <h3 class="news-topic">価格改定のお知らせ</h3>


### PR DESCRIPTION
## 変更内容
期間限定で、冷やし中華が始まったことを知らせるお知らせを追加。
お知らせのタグは、「お知らせ」とした。

## 変更理由
オーナーより、変更の依頼があったため。
メニューの写真等は受け取っていないので、お知らせ欄だけに追加をした。